### PR TITLE
[Fix] 공용책 불러오기 pdf_url 수정

### DIFF
--- a/backend_django/books/serializers.py
+++ b/backend_django/books/serializers.py
@@ -35,8 +35,7 @@ class BookOfficialResponseSerializer(serializers.Serializer):
     pdf_url = serializers.SerializerMethodField()
     
     def get_pdf_url(self, obj):
-        # 현재 DB에 pdf_url 컬럼이 없으므로 임시 URL 반환
-        return f"https://cdn.example.com/books/{obj.id}.pdf"
+        return obj.pdf_url
 
 class BookVideoResponseSerializer(serializers.Serializer):
     video_id=serializers.IntegerField(source='id')


### PR DESCRIPTION
## #️⃣연관된 이슈

> [Fix] 공용책 불러오기 pdf_url 수정 #71 

## 📝작업 내용

> GET /books/official API에서 기존에 DB에 pdf_url이 없어 임시로 하드코딩했던 부분 수정
=> 책 썸네일을 제대로 불러올 수 있게 됨

### 스크린샷 (선택)

<img width="834" height="800" alt="image" src="https://github.com/user-attachments/assets/c22b6964-c9ff-4f17-8b57-63e2778a4fa2" />

<img width="1820" height="861" alt="image" src="https://github.com/user-attachments/assets/83b5fd81-3e98-44fa-a971-d7b1c2cb4754" />
