### PR TITLE
fix: 인증 기능에 csrf 허용

### DIFF
--- a/backend_django/.dockerignore
+++ b/backend_django/.dockerignore
@@ -1,0 +1,78 @@
+# Python 캐시 파일
+__pycache__/
+*.py[cod]
+*$py.class
+*.so
+
+# 가상환경
+venv/
+env/
+ENV/
+
+# IDE 설정
+.vscode/
+.idea/
+*.swp
+*.swo
+
+# OS 파일
+.DS_Store
+Thumbs.db
+
+# Git
+.git/
+.gitignore
+
+# Docker 관련
+Dockerfile
+docker-compose*.yml
+.dockerignore
+
+# 로그 파일
+*.log
+
+# 데이터베이스
+*.db
+*.sqlite3
+
+# 환경 변수 파일
+.env*
+
+# 테스트 커버리지
+.coverage
+htmlcov/
+
+# 노드 모듈 (있는 경우)
+node_modules/
+
+# 임시 파일
+*.tmp
+*.temp
+
+# 정적 파일 (빌드 시 생성되므로)
+staticfiles/
+
+# 미디어 파일 (운영에서는 S3 사용)
+media/
+
+# 백업 파일
+*.bak
+*.backup
+
+# 압축 파일
+*.zip
+*.tar.gz
+*.rar
+
+# 문서
+README.md
+docs/
+
+# 테스트 관련
+pytest_cache/
+.tox/
+
+# mypy
+.mypy_cache/
+.dmypy.json
+dmypy.json 

--- a/backend_django/config/settings_prod.py
+++ b/backend_django/config/settings_prod.py
@@ -57,15 +57,29 @@ CORS_ALLOWED_ORIGINS = [
     "http://www.epi-log.site",
 ]
 
-# 개발/테스트용 (필요시)
+# 개발/테스트용 (Postman, 로컬 클라이언트 등)
 CORS_ALLOWED_ORIGIN_REGEXES = [
     r"^https://.*\.epi-log\.site$",
     r"^http://.*\.epi-log\.site$",
 ]
 
+# 추가 허용 오리진 (필요시)
+# CORS_ALLOWED_ORIGINS += [
+#     "http://localhost:3000",    # React 개발 서버
+#     "http://127.0.0.1:3000",   # 로컬 프론트엔드
+# ]
+
 # CORS 헤더 설정
 CORS_ALLOW_CREDENTIALS = True
-CORS_ALLOW_ALL_ORIGINS = False  # 보안을 위해 특정 도메인만 허용
+CORS_ALLOW_ALL_ORIGINS = False  # 보안: 특정 도메인만 허용
+
+# CORS 허용 헤더 (JWT 토큰 전송용)
+CORS_ALLOW_HEADERS = [
+    'authorization',
+    'content-type',
+    'x-csrftoken',
+    'x-requested-with',
+]
 
 # CSRF 신뢰할 수 있는 출처 설정
 CSRF_TRUSTED_ORIGINS = [

--- a/backend_django/config/settings_prod.py
+++ b/backend_django/config/settings_prod.py
@@ -325,6 +325,16 @@ SIMPLE_JWT = {
     'USER_ID_FIELD': 'id',
     'USER_ID_CLAIM': 'user_id',
     'USER_AUTHENTICATION_RULE': 'rest_framework_simplejwt.authentication.default_user_authentication_rule',
+
+    "AUTH_COOKIE_ACCESS": "access",
+    "AUTH_COOKIE_REFRESH": "refresh",
+    "AUTH_COOKIE_SAMESITE": "Lax",
+    "AUTH_COOKIE_SECURE": True,     # 운영이면 True 필수
+    "AUTH_COOKIE_HTTP_ONLY": True,
+    "AUTH_COOKIE_PATH": "/",
+    "AUTH_COOKIE_DOMAIN": "epi-log.site",
+    "AUTH_COOKIE_ACCESS_MAX_AGE": 60 * 60 * 24,
+    "AUTH_COOKIE_REFRESH_MAX_AGE": 60 * 60 * 24 * 7,
     
     # 토큰 클래스 설정
     'AUTH_TOKEN_CLASSES': ('rest_framework_simplejwt.tokens.AccessToken',),

--- a/backend_django/config/settings_prod.py
+++ b/backend_django/config/settings_prod.py
@@ -77,6 +77,19 @@ CORS_ALLOW_HEADERS = [
     'content-type',
     'x-csrftoken',
     'x-requested-with',
+    'x-password',
+    'accept',
+    'origin',
+    'user-agent',
+]
+
+CORS_ALLOW_METHODS = [
+    'GET',
+    'POST',
+    'PUT',
+    'PATCH',
+    'DELETE',
+    'OPTIONS',
 ]
 
 # CSRF 신뢰할 수 있는 출처 설정

--- a/backend_django/config/settings_prod.py
+++ b/backend_django/config/settings_prod.py
@@ -1,6 +1,4 @@
 # settings_prod.py
-
-
 """
 Django settings for backend_django project.
 
@@ -93,10 +91,10 @@ CSRF_TRUSTED_ORIGINS = [
 # JWT 기반 API에서는 별도 CSRF 설정 불필요
 
 # 배포용/(근데 실제로 사용은 안했음.)
-SECURE_SSL_REDIRECT = False
+SECURE_SSL_REDIRECT = True
 SECURE_REDIRECT_EXEMPT = [r'^metrics/?$']  # /metrics 경로는 HTTPS 리다이렉트 제외
-SESSION_COOKIE_SECURE = False
-CSRF_COOKIE_SECURE = False
+SESSION_COOKIE_SECURE = True
+CSRF_COOKIE_SECURE = True
 
 
 # OpenAI API 키

--- a/backend_django/config/settings_prod.py
+++ b/backend_django/config/settings_prod.py
@@ -49,6 +49,35 @@ SECURE_PROXY_SSL_HEADER = ('HTTP_X_FORWARDED_PROTO', 'https')
 # 배포 서버
 BACKEND_DOMAIN = 'epi-log.site'
 
+# CORS 설정 (배포용)
+CORS_ALLOWED_ORIGINS = [
+    "https://epi-log.site",
+    "http://epi-log.site",
+    "https://www.epi-log.site",
+    "http://www.epi-log.site",
+]
+
+# 개발/테스트용 (필요시)
+CORS_ALLOWED_ORIGIN_REGEXES = [
+    r"^https://.*\.epi-log\.site$",
+    r"^http://.*\.epi-log\.site$",
+]
+
+# CORS 헤더 설정
+CORS_ALLOW_CREDENTIALS = True
+CORS_ALLOW_ALL_ORIGINS = False  # 보안을 위해 특정 도메인만 허용
+
+# CSRF 신뢰할 수 있는 출처 설정
+CSRF_TRUSTED_ORIGINS = [
+    "https://epi-log.site",
+    "http://epi-log.site", 
+    "https://www.epi-log.site",
+    "http://www.epi-log.site",
+]
+
+# 참고: Django REST Framework의 APIView는 자동으로 csrf_exempt 적용됨
+# JWT 기반 API에서는 별도 CSRF 설정 불필요
+
 # 배포용/(근데 실제로 사용은 안했음.)
 SECURE_SSL_REDIRECT = False
 SECURE_REDIRECT_EXEMPT = [r'^metrics/?$']  # /metrics 경로는 HTTPS 리다이렉트 제외
@@ -102,6 +131,7 @@ INSTALLED_APPS = [
 
 MIDDLEWARE = [
     'django_prometheus.middleware.PrometheusBeforeMiddleware',
+    'corsheaders.middleware.CorsMiddleware',  # CORS 미들웨어 추가
     'django.middleware.security.SecurityMiddleware',
     'django.contrib.sessions.middleware.SessionMiddleware',
     'django.middleware.common.CommonMiddleware',
@@ -242,6 +272,14 @@ REST_FRAMEWORK = {
     ],
     'DEFAULT_PERMISSION_CLASSES': [
         'rest_framework.permissions.IsAuthenticated',
+    ],
+    'DEFAULT_RENDERER_CLASSES': [
+        'rest_framework.renderers.JSONRenderer',
+    ],
+    'DEFAULT_PARSER_CLASSES': [
+        'rest_framework.parsers.JSONParser',
+        'rest_framework.parsers.FormParser',
+        'rest_framework.parsers.MultiPartParser',
     ],
 }
 

--- a/backend_django/docker-compose.prod.yml
+++ b/backend_django/docker-compose.prod.yml
@@ -121,7 +121,7 @@ services:
     image: traefik:v2.9
     container_name: backend-traefik
     command:
-      - "--api.insecure=false"
+      - "--api.insecure=true"
       - "--providers.docker=true"
       - "--entrypoints.web.address=:80"
       - "--api.dashboard=true"

--- a/backend_django/docker-compose.prod.yml
+++ b/backend_django/docker-compose.prod.yml
@@ -33,7 +33,7 @@ services:
     image: backend-django
     container_name: backend-django
     build: .
-    command: python -m gunicorn config.wsgi:application --bind 0.0.0.0:8000 # Gunicorn을 사용하여 Django 애플리케이션 실행
+    command: python -m gunicorn config.wsgi:application --bind 0.0.0.0:8000 --reload # Gunicorn을 사용하여 Django 애플리케이션 실행
     volumes:
       - .:/backend
       - ./gcp-key.json:/app/gcp-key.json # GCP veo 키 파일 마운트

--- a/backend_django/docker-compose.prod.yml
+++ b/backend_django/docker-compose.prod.yml
@@ -125,6 +125,10 @@ services:
       - "--providers.docker=true"
       - "--entrypoints.web.address=:80"
       - "--api.dashboard=true"
+      - "--accesslog=true" # 이 라인 추가
+      - "--accesslog.filepath=/var/log/traefik/access.log" # (선택 사항) 파일로 저장
+      - "--accesslog.format=json" # (선택 사항) JSON 형식으로 로그
+      - "--log.level=DEBUG" # 디버그 레벨 로그 (자세한 정보)
       - "--entrypoints.websecure.address=:443" # 중요 - Traefik이 HTTPS 요청을 수신할 포트 443을 열음
       - "--entrypoints.web.http.redirections.entrypoint.to=websecure" # 중요 - HTTP 요청을 HTTPS로 리다이렉트
       - "--entrypoints.web.http.redirections.entrypoint.scheme=https" # 중요 => HTTPS 강제 적용

--- a/backend_django/docker-compose.prod.yml
+++ b/backend_django/docker-compose.prod.yml
@@ -121,7 +121,7 @@ services:
     image: traefik:v2.9
     container_name: backend-traefik
     command:
-      - "--api.insecure=true"
+      - "--api.insecure=false"
       - "--providers.docker=true"
       - "--entrypoints.web.address=:80"
       - "--api.dashboard=true"

--- a/backend_django/users/views.py
+++ b/backend_django/users/views.py
@@ -14,6 +14,8 @@ from rest_framework_simplejwt.views import TokenRefreshView
 from rest_framework_simplejwt.serializers import TokenRefreshSerializer
 # from rest_framework_simplejwt.tokens import RefreshToken  # 기본 토큰 주석처리
 from users.tokens import CustomRefreshToken  # 커스텀 토큰 사용
+from django.views.decorators.csrf import csrf_exempt  # CSRF 면제 데코레이터 추가
+from django.utils.decorators import method_decorator  # 클래스 기반 뷰에 데코레이터 적용
 from users.serializers import (
     LoginSerializer, 
     SignupSerializer, 
@@ -102,6 +104,7 @@ from drf_yasg import openapi
 
 
 # ========== JWT API 뷰들 ==========
+@method_decorator(csrf_exempt, name='dispatch')
 class LoginAPIView(APIView):
     """JWT 로그인 API"""
     permission_classes = [AllowAny] # 누구나 접근 가능(로그인이기 때문에)
@@ -163,6 +166,7 @@ class LoginAPIView(APIView):
         }, status=status.HTTP_400_BAD_REQUEST)
 
 
+@method_decorator(csrf_exempt, name='dispatch')
 class SignupAPIView(APIView):
     """JWT 회원가입 API"""
     permission_classes = [AllowAny] # 누구나 접근 가능(회원가입 기능이므로)


### PR DESCRIPTION
## #️⃣연관된 이슈

> ex) #이슈번호, #이슈번호
#70 

## 📝작업 내용
1. 배포서버에서 회원가입시 CSRF, 403 코드가 뜨는 것을 해결!

> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)

저녁에 쉬고와서 해결할려고 보니 문뜩 생각났다.

<img width="701" height="520" alt="스크린샷 2025-07-22 오후 8 12 49" src="https://github.com/user-attachments/assets/7b3672ae-540e-48b4-8a25-e7973f4dc1a1" />

JWT 인증 기능을 구현하며 회원가입, 로그인 템플릿이 나타나지 않도록 주석처리 했는데 왜 사이트에 접속하면 로그인 페이지로 리다이렉션 되지..?
그래서 혹시나 싶어서 도커 컨테이너를 내린 후 캐시 없이 빌드해보았다.

<img width="701" height="520" alt="스크린샷 2025-07-22 오후 6 02 08" src="https://github.com/user-attachments/assets/c0a69bf9-d6a2-4a06-adf4-721c81157e8d" />
그랬더니 배포서버 엔드포인트로 회원가입, 책 목록 조회가 잘 되었다!!

<img width="672" height="687" alt="스크린샷 2025-07-22 오후 8 16 43" src="https://github.com/user-attachments/assets/892b603a-422d-49a6-9562-c8245c9751f0" />

# 느낀점
왜 새로 고친 코드가 잘 반영이 안되었던걸까...
하면서 찾아보았는데 Dockerfile의 레이어 캐시 문제임을 발견했다.
즉, COPY 명령어를 실행할때 이전과 코드가 비슷하면 똑같은 내용으로 카피하는듯..

이를 위해 .dockerignore를 정의하고 docker-compose.prod.yml에서 Gunicorn에 --reload를 설정하였다...
나중에 배포하는데 같은 문제가 생기면... 그냥 도커를 빌드할때 캐시없이 할 수 밖에...


